### PR TITLE
Allow text > 2

### DIFF
--- a/currencies.cabal
+++ b/currencies.cabal
@@ -25,7 +25,7 @@ library
                      , Data.Currency.Amounts
                      , Data.Currency.Pretty
   build-depends:       base >= 4.7 && < 5
-                     , text >= 1.2 && < 2
+                     , text >= 1.2 && < 2.2
   default-language:    Haskell2010
   ghc-options:         -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
 
@@ -37,7 +37,7 @@ test-suite currencies-test
   build-depends:       base
                      , currencies
                      , hspec >= 2.0 && < 3
-                     , text >= 1.2 && < 2
+                     , text >= 1.2 && < 2.2
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 


### PR DESCRIPTION
This change allows the library to work with newer versions of `text`